### PR TITLE
added a java style guide referencing Google's

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -1,0 +1,10 @@
+# Java
+
+## Introduction
+
+This styleguide covers the Java programming language at Lookout. 
+
+## Inspiration
+
+The current de-facto standard at Lookout is the use of the Google style guide: https://google-styleguide.googlecode.com/svn/trunk/javaguide.html
+


### PR DESCRIPTION
Not sure how we want to wrap pointers to other style guides -- but Google's for Java is about as correct as it gets (though I do take exception to some of their conventions like never using a wildcard import).
